### PR TITLE
Clear item rect caches between sections

### DIFF
--- a/PSTCollectionView/PSTCollectionViewFlowLayout.m
+++ b/PSTCollectionView/PSTCollectionViewFlowLayout.m
@@ -133,6 +133,9 @@ NSString *const PSTFlowLayoutRowVerticalAlignmentKey = @"UIFlowLayoutRowVertical
                     }
                 }
             }
+            
+            // Reset the item rect cache for this section
+            _cachedItemRects = nil;
         }
     }
     return layoutAttributesArray;


### PR DESCRIPTION
Using the item rect caches from the previous section for the new section can cause a NSRangeException when the number of items in the first row of the previous section is less than the number of items in the first row of the new section.

Signed-off-by: Daniel Thorpe daniel.thorpe@corp.badoo.com
