### PR TITLE
Default value for allowsSelection: YES

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -102,6 +102,7 @@ const char kPSTNibLayout;
 #pragma mark - NSObject
 
 static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
+    _self.allowsSelection = YES;
     _self.delaysContentTouches = NO;
     _self->_indexPathsForSelectedItems = [NSMutableSet new];
     _self->_indexPathsForHighlightedItems = [NSMutableSet new];


### PR DESCRIPTION
Set default value of allowsSelection. Otherwise breaks code that relies on selection.

Please check defaults in PSTCollectionViewFlowLayout (minimumLineSpacing, minimumInteritemSpacing, itemSize) - they are different too; didn't check other classes.
