### PR TITLE
Index paths for visible items improvement

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -409,16 +409,16 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
 }
 
 - (NSArray *)indexPathsForVisibleItems {
-    NSMutableArray *visibleItems = [NSMutableArray array];
-    for (PSTCollectionViewCell *cell in [self visibleCells]) {
-        NSIndexPath *indexPath = [self indexPathForCell:cell];
-        if (indexPath) {
-            [visibleItems addObject:indexPath];
-        }else {
-            NSLog(@"Error: indexPath not found");
-        }
-    }
-    return visibleItems;
+	NSMutableArray *indexPaths = [NSMutableArray arrayWithCapacity:[_allVisibleViewsDict count]];
+	
+	[_allVisibleViewsDict enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+		PSTCollectionViewItemKey *itemKey = (PSTCollectionViewItemKey *)key;
+        if (itemKey.type == PSTCollectionViewItemTypeCell) {
+			[indexPaths addObject:itemKey.indexPath];
+		}
+	}];
+	
+	return indexPaths;
 }
 
 // Interacting with the collection view.


### PR DESCRIPTION
Existing implementation iterated over the result from visibleCells and then called indexPathForCell for each cell both of which iterated over the _allVisibleViewsDict giving us a runtime of O(n^2)

new implementation just iterates over _allVisibleViewsDict like the methods of similar nature

My apologies for the merge commit, we're having some sub-module madness in the office
