### PR TITLE
Load PSTCollectionViewFlowLayout correctly from nib

### DIFF
--- a/PSTCollectionView/PSTCollectionViewFlowLayout.m
+++ b/PSTCollectionView/PSTCollectionViewFlowLayout.m
@@ -86,6 +86,20 @@ NSString *const PSTFlowLayoutRowVerticalAlignmentKey = @"UIFlowLayoutRowVertical
     return self;
 }
 
+- (id)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        self.itemSize = [aDecoder decodeCGSizeForKey:@"UIItemSize"];
+        self.minimumInteritemSpacing = [aDecoder decodeFloatForKey:@"UIInteritemSpacing"];
+        self.minimumLineSpacing = [aDecoder decodeFloatForKey:@"UILineSpacing"];
+        self.footerReferenceSize = [aDecoder decodeCGSizeForKey:@"UIFooterReferenceSize"];
+        self.headerReferenceSize = [aDecoder decodeCGSizeForKey:@"UIHeaderReferenceSize"];
+        self.sectionInset = [aDecoder decodeUIEdgeInsetsForKey:@"UISectionInset"];
+        self.scrollDirection = [aDecoder decodeIntegerForKey:@"UIScrollDirection"];
+    }
+    return self;
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - PSTCollectionViewLayout
 


### PR DESCRIPTION
If we load the flow layout correctly from the NIB everything seems to look right in iOS 5, at least for CollectionView-Simple
