### PR TITLE
Fix the problem that each row adds one extra iter-item spacing

### DIFF
--- a/PSTCollectionView/PSTGridLayoutSection.m
+++ b/PSTCollectionView/PSTGridLayoutSection.m
@@ -82,7 +82,9 @@
             }
             CGSize itemSize = self.fixedItemSize ? self.itemSize : item.itemFrame.size;
             CGFloat itemDimension = self.layoutInfo.horizontal ? itemSize.height : itemSize.width;
-            itemDimension += self.layoutInfo.horizontal ? self.verticalInterstice : self.horizontalInterstice;
+            // first item does not add spacing
+            if (row)
+                itemDimension += self.layoutInfo.horizontal ? self.verticalInterstice : self.horizontalInterstice;
             if (dimensionLeft < itemDimension || finishCycle) {
                 // finish current row
                 if (row) {


### PR DESCRIPTION
Suppose the screen width is 320 and two items with width of 155 each, plus the default iter-item spacing of 10. On iOS6 the flow layout fits the two items tightly on the same row, but PSTCollectionView on iOS5 doesn't.
Problem was that each item including the first one added its own spacing thus double counts by one per row.
