### PR TITLE
changed flowDataSource to be collection view’s delegate property, according to apple documentation.

### DIFF
--- a/PSTCollectionView/PSTCollectionViewFlowLayout.m
+++ b/PSTCollectionView/PSTCollectionViewFlowLayout.m
@@ -247,7 +247,7 @@ static char kPSTCachedItemRectsKey;
 - (void)getSizingInfos {
     NSAssert([_data.sections count] == 0, @"Grid layout is already populated?");
 
-    id <PSTCollectionViewDelegateFlowLayout> flowDataSource = (id <PSTCollectionViewDelegateFlowLayout>)self.collectionView.dataSource;
+    id <PSTCollectionViewDelegateFlowLayout> flowDataSource = (id <PSTCollectionViewDelegateFlowLayout>)self.collectionView.delegate;
 
     BOOL implementsSizeDelegate = [flowDataSource respondsToSelector:@selector(collectionView:layout:sizeForItemAtIndexPath:)];
 


### PR DESCRIPTION
I noticed some changes in the way my collection view looked between iOS 5 and 6.
tracked it down to this issue.

[Reference](http://developer.apple.com/library/ios/#documentation/UIKit/Reference/UICollectionViewDelegateFlowLayout_protocol/Reference/Reference.html) (last paragraph in overview section)
