### PR TITLE
Fixed shadowed variable warning

### DIFF
--- a/PSTCollectionView/PSTGridLayoutRow.m
+++ b/PSTCollectionView/PSTGridLayoutRow.m
@@ -104,7 +104,7 @@
         // calculate row frame as union of all items
         CGRect frame = CGRectZero;
         CGRect itemFrame = (CGRect){.size=self.section.itemSize};
-        for (NSInteger itemIndex = 0; itemIndex < self.itemCount; itemIndex++) {
+        for (itemIndex = 0; itemIndex < self.itemCount; itemIndex++) {
             PSTGridLayoutItem *item = nil;
             if (!self.fixedItemSize) {
                 item = self.items[itemIndex];


### PR DESCRIPTION
Fixes a shadowed local variable warning that was bugging me.
