### PR TITLE
Allow deselection / selection when allowsMultipleSelection is on

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -588,7 +588,7 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
 - (void)selectItemAtIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated scrollPosition:(PSTCollectionViewScrollPosition)scrollPosition notifyDelegate:(BOOL)notifyDelegate {
 
     BOOL shouldSelect = YES;
-	if (_collectionViewFlags.delegateShouldSelectItemAtIndexPath) {
+	if (notifyDelegate && _collectionViewFlags.delegateShouldSelectItemAtIndexPath) {
         shouldSelect = [self.delegate collectionView:self shouldSelectItemAtIndexPath:indexPath];
     }
 


### PR DESCRIPTION
Currently the collectionview only sends a message to the delegate that it has been selected and doesn't take the selectedIndexes into account. This PR will instead send the deselect message to the delegate.

I've also added it so that when you toggle allowsMutlipleSelection off it will remove all the current selection.
