### PR TITLE
Cells should be above supplementary views but below scroll indicators

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -1014,7 +1014,7 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
 
 - (void)addControlledSubview:(PSTCollectionReusableView *)subview {
 	// avoids placing views above the scroll indicator
-    [self insertSubview:subview atIndex:0];
+    [self insertSubview:subview atIndex:self.subviews.count - (self.dragging ? 1 : 0)];
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Previous fix from the supplementary view commits only prepended cells to the front of the subview queue to avoid covering scroll indicators. This however breaks the iOS6 UICollectionView behavior that subviews should be ordered based on when they are queued (I think cells are mostly always above other views).

Made a simple change to detect visibility of the scroll indicators and if so, insert the cell below the last subview, which is always a scroll indicator in iOS5 and below.

Should fix #36.
