### PR TITLE
Fix the reloads count so you can actually use reloadData

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -1673,6 +1673,7 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
     _update = nil;
     _updateCount--;
     _collectionViewFlags.updating = NO;
+    [self resumeReloads];
 }
 
 


### PR DESCRIPTION
Calling [self.collectionView reloadData] is broken in ios 5.1
