### PR TITLE
fix unused variable warning

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -1565,6 +1565,7 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
         @([operations[@(sortedItem.indexPathAfterUpdate.section)][@"movedIn"] intValue]+1);
     }
 
+#if !defined  NS_BLOCK_ASSERTIONS
     for(NSNumber *sectionKey in [operations keyEnumerator]) {
         NSInteger section = [sectionKey intValue];
         
@@ -1582,7 +1583,8 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
                  [oldCollectionViewData numberOfItemsInSection:section],
                  insertedCount,deletedCount,movedInCount, movedOutCount);
     }
-    
+#endif
+
     [someMutableArr2 addObjectsFromArray:sortedDeletedMutableItems];
     [someMutableArr3 addObjectsFromArray:sortedInsertMutableItems];
     [someMutableArr1 addObjectsFromArray:[someMutableArr2 sortedArrayUsingSelector:@selector(inverseCompareIndexPaths:)]];


### PR DESCRIPTION
# ifdef the whole loop in NS_BLOCK_ASSERTIONS

to prevent an unused variable warning.

could also be done with #pragma unused (..,...,) but I thought ifdeffing the whole block makes it a bit easier to read. 
