### PR TITLE
Modify UIView's frame instead of CALayer's frame in applyLayoutAttributes:

### DIFF
--- a/PSTCollectionView/PSTCollectionViewCell.m
+++ b/PSTCollectionView/PSTCollectionViewCell.m
@@ -53,10 +53,9 @@
 - (void)applyLayoutAttributes:(PSTCollectionViewLayoutAttributes *)layoutAttributes {
     if (layoutAttributes != _layoutAttributes) {
         _layoutAttributes = layoutAttributes;
-//        self.frame = layoutAttributes.frame;
 
-        self.layer.frame = layoutAttributes.frame;
-        self.layer.position = layoutAttributes.center;
+        self.frame = layoutAttributes.frame;
+        self.center = layoutAttributes.center;
 
         self.hidden = layoutAttributes.isHidden;
         self.layer.transform = layoutAttributes.transform3D;


### PR DESCRIPTION
Changing the CALayer's frame instead of the UIView's frame prevents the subviews from resizing correctly. This can result in an incorrectly-sized contentView and other views that have been added to the view hierarchy.

It used to be this way, but was changed in ef34a177. I'm not sure why it was. Is there a reason this change was made in the first place?
