### PR TITLE
Fix linelayout example by removing invalid bound checks

### DIFF
--- a/PSTCollectionView/PSTCollectionViewData.m
+++ b/PSTCollectionView/PSTCollectionViewData.m
@@ -87,10 +87,6 @@
     [self validateItemCounts];
     [self prepareToLoadData];
     
-    // rect.size should be within _contentSize
-    rect.size.width = fminf(rect.size.width, _contentSize.width);
-    rect.size.height = fminf(rect.size.height, _contentSize.height);
-    
     // TODO: check if we need to fetch data from layout
     if (!CGRectEqualToRect(_validLayoutRect, rect)) {
         _validLayoutRect = rect;


### PR DESCRIPTION
I am not sure why these two constraints were added.

_contentSize only defines a size, not origin, thus taking minimums of that will produce an invalid bounding rect.

In fact, layoutAttributesForElementsInRect: will need the entire rect (visible area) to calculate all on-screen elements.

With this change and the latest master commit, all examples are tested working again.
