### PR TITLE
Fix for -[PSTCollectionView insertSections:]

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -1767,7 +1767,7 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
 
 - (void)updateSections:(NSIndexSet *)sections updateAction:(PSTCollectionUpdateAction)updateAction {
     BOOL updating = _collectionViewFlags.updating;
-    if(updating) {
+    if(!updating) {
         [self setupCellAnimations];
     }
     


### PR DESCRIPTION
A call to -[PSTCollectionView insertSections:] has no balanced calls of suspendReloads/resumeReloads and therefore the -[PSTCollectionView reloadData] call has no effect afterwards
