### PR TITLE
Cell LayoutAttributes Should be Applied Before "cellForItemAtIndexPath:"

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -312,6 +312,8 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
     // de-queue cell (if available)
     NSMutableArray *reusableCells = _cellReuseQueues[identifier];
     PSTCollectionViewCell *cell = [reusableCells lastObject];
+    PSTCollectionViewLayoutAttributes *attributes = [self.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath];
+
     if (cell) {
         [reusableCells removeObjectAtIndex:[reusableCells count]-1];
     }else {
@@ -334,8 +336,7 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
             if (cellClass == nil) {
                 @throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"Class not registered for identifier %@", identifier] userInfo:nil];
             }
-            if (self.collectionViewLayout) {
-                PSTCollectionViewLayoutAttributes *attributes = [self.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath];
+            if (attributes) {
                 cell = [[cellClass alloc] initWithFrame:attributes.frame];
             } else {
                 cell = [cellClass new];
@@ -349,6 +350,9 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
         cell.collectionView = self;
         cell.reuseIdentifier = identifier;
     }
+
+    [cell applyLayoutAttributes:attributes];
+    
     return cell;
 }
 
@@ -356,6 +360,9 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
 	NSString *kindAndIdentifier = [NSString stringWithFormat:@"%@/%@", elementKind, identifier];
     NSMutableArray *reusableViews = _supplementaryViewReuseQueues[kindAndIdentifier];
     PSTCollectionReusableView *view = [reusableViews lastObject];
+    PSTCollectionViewLayoutAttributes *attributes = [self.collectionViewLayout layoutAttributesForSupplementaryViewOfKind:elementKind
+                                                                                                              atIndexPath:indexPath];
+    
     if (view) {
         [reusableViews removeObjectAtIndex:reusableViews.count - 1];
     } else {
@@ -377,10 +384,8 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
 			if (viewClass == nil) {
 				@throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"Class not registered for kind/identifier %@", kindAndIdentifier] userInfo:nil];
 			}
-			if (self.collectionViewLayout) {
-				PSTCollectionViewLayoutAttributes *attributes = [self.collectionViewLayout layoutAttributesForSupplementaryViewOfKind:elementKind
-																														  atIndexPath:indexPath];
-				view = [[viewClass alloc] initWithFrame:attributes.frame];
+			if (attributes) {
+					view = [[viewClass alloc] initWithFrame:attributes.frame];
 			} else {
 				view = [viewClass new];
 			}
@@ -388,6 +393,9 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
         view.collectionView = self;
         view.reuseIdentifier = identifier;
     }
+
+    [view applyLayoutAttributes:attributes];
+    
     return view;
 }
 
@@ -1200,8 +1208,7 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
     
     // voiceover support
     cell.isAccessibilityElement = YES;
-    
-    [cell applyLayoutAttributes:layoutAttributes];
+
     return cell;
 }
 
@@ -1212,7 +1219,6 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
 		PSTCollectionReusableView *view = [self.dataSource collectionView:self
 										viewForSupplementaryElementOfKind:kind
 															  atIndexPath:indexPath];
-		[view applyLayoutAttributes:layoutAttributes];
 		return view;
 	}
 	return nil;


### PR DESCRIPTION
After doing some testing, it looks like UICollectionView applies LayoutAttributes during "dequeueReusableCellWithReuseIdentifier:forIndexPath:". PSTCollectionCurrently applies them after the call to "collectionView:cellForItemAtIndexPath:". I can go through and update this, but your thoughts would be appreciated, @steipete. 
