### PR TITLE
Fix highlighting behavior and reorganize how selection and highlighting ...

### DIFF
--- a/PSTCollectionView/PSTCollectionViewCell.m
+++ b/PSTCollectionView/PSTCollectionViewCell.m
@@ -150,28 +150,22 @@
 }
 
 - (void)setSelected:(BOOL)selected {
-    if (_collectionCellFlags.selected != selected) {
-        _collectionCellFlags.selected = selected;
-        [self updateBackgroundView];
-    }
+    _collectionCellFlags.selected = selected;
 }
 
 - (void)setHighlighted:(BOOL)highlighted {
     if (_collectionCellFlags.highlighted != highlighted) {
         _collectionCellFlags.highlighted = highlighted;
-        [self updateBackgroundView];
+        _selectedBackgroundView.alpha = highlighted ? 1.0f : 0.0f;
+        [self setHighlighted:highlighted forViews:self.contentView.subviews];
     }
-}
-
-- (void)updateBackgroundView {
-    BOOL shouldHighlight = (self.highlighted || self.selected);
-    _selectedBackgroundView.alpha = shouldHighlight ? 1.0f : 0.0f;
-    [self setHighlighted:shouldHighlight forViews:self.contentView.subviews];
 }
 
 - (void)setHighlighted:(BOOL)highlighted forViews:(id)subviews {
     for (id view in subviews) {
-        if ([view respondsToSelector:@selector(setHighlighted:)]) {
+        // Ignore the events if view wants to
+        if (!((UIView *)view).isUserInteractionEnabled &&
+            [view respondsToSelector:@selector(setHighlighted:)]) {
             [view setHighlighted:highlighted];
         }
         [self setHighlighted:highlighted forViews:[view subviews]];


### PR DESCRIPTION
...iteract

Several things are modified / optimized to make highlighting work better in selection modes:
1. UIViews with userInteractionEnabled = True are no longer highlighted by selection. Noticed this because I had a UIButton within a cell and iOS6 UICollectionView does not highlight it when cell is selected.
2. Highlight attribute of UIViews within a cell should stay on when a cell is being clicked consecutively. Checked .highlight before and after selection with iOS6 to correct this behavior.
   There were some very confusing unhighlight calls and got removed.
3. There were code paths with something like this: highlight ON -> check & change background, highlight OFF -> check & change background, selection ON -> check & change background, highlight OFF -> check & change background ... they looked inefficient and quite brain baffling because background was being controlled by two different code paths. I think the main confusion is that selection must highlight a cell while touchEvents need to highlight as well. So I reorganized and now selection path will only be keeping states of which indexPath(s) are selected and highlighting path will control how and when each UIView within cell is highlighted / unhighlighted. There will be one highlight ON for each selection instead of multiple checks.

Checked with SelectionDelegateExample and to the best of my knowledge these changes do not break anything. Well, I won't be surprised if there are corner cases I haven't seen.
