### PR TITLE
fix incompatible pointer type warning for Deployment Targets >= iOS 6.0

### DIFF
--- a/PSTCollectionView/PSTCollectionViewController.m
+++ b/PSTCollectionView/PSTCollectionViewController.m
@@ -27,7 +27,7 @@
 - (id)initWithCoder:(NSCoder *)coder {
     self = [super initWithCoder:coder];
     if (self) {
-		self.layout = [PSUICollectionViewFlowLayout new];
+		self.layout = [PSTCollectionViewFlowLayout new];
         self.clearsSelectionOnViewWillAppear = YES;
         _collectionViewControllerFlags.appearsFirstTime = YES;
     }


### PR DESCRIPTION
The _layout ivar is of type PSTCollectionViewLayout; if targeting >= iOS6.0, PSUICollectionViewFlowLayout is redefined to UICollectionViewFlowLayout, which is an incompatible pointer type with PSTCollectionViewLayout.

I believe the intent was to assign PSTCollectionViewFlowLayout, regardless of deployment target.
