### PR TITLE
-[PSTCollectionViewFlowLayout updateItemsLayout] changes to correct contentSize.

### DIFF
--- a/PSTCollectionView/PSTCollectionViewFlowLayout.m
+++ b/PSTCollectionView/PSTCollectionViewFlowLayout.m
@@ -365,11 +365,11 @@ static char kPSTCachedItemRectsKey;
         if (_data.horizontal) {
             sectionFrame.origin.x += contentSize.width;
             contentSize.width += section.frame.size.width + section.frame.origin.x;
-            contentSize.height = fmaxf(contentSize.height, sectionFrame.size.height + section.frame.origin.y);
+            contentSize.height = fmaxf(contentSize.height, sectionFrame.size.height + section.frame.origin.y + section.sectionMargins.top + section.sectionMargins.bottom);
         }else {
             sectionFrame.origin.y += contentSize.height;
             contentSize.height += sectionFrame.size.height + section.frame.origin.y;
-            contentSize.width = fmaxf(contentSize.width, sectionFrame.size.width + section.frame.origin.x);
+            contentSize.width = fmaxf(contentSize.width, sectionFrame.size.width + section.frame.origin.x + section.sectionMargins.left + section.sectionMargins.right);
         }
         section.frame = sectionFrame;
     }


### PR DESCRIPTION
There was a mismatch in PSTCollectionView.contentSize and UICollectionView.contentSize. I made two changes.
- I removed the minimum `contentSize` setter in `-[PSTCollectionViewFlowLayout updateItemsLayout]`. Basically, I'm seeing that with a contentSize the full height of the bounds, I can scroll the collection into the contentInset and leave it there (which is appropriate for that contentSize). That's with both `alwaysBounceVertical=YES` and NO. By removing @matej's patch ([Issue #117](https://github.com/steipete/PSTCollectionView/issues/117)), the contentSize and scrolling functionality almost perfectly matches UICollectionView, with or without alwaysBounce. _See change 2 for perfect match._

After removing that patch, I'm not seeing what @matej saw. That issue was probably fixed by something else (or I'm incorrectly replicating his test, which appears to just be having fewer items than would fill the view).

Console prints comparing UICollectionView and PSTCollectionView, with PSTFlowLayout having the minimum `contentSize` setter, at https://gist.github.com/4588668

![ContentInset PSTCollectionView](https://f.cloud.github.com/assets/377298/84189/fb2a9bde-6403-11e2-8e0b-85cdb90dea2b.png)
- Added sectionMargin to contentSize in the non-scrolling direction (.width if scrolling vertically). I'm not entirely sure why the scrolled directions were equal and the un-scrolled need this sectionMargin addition here, I suspect it has to do with `-[PSTGridLayoutSection computeLayout]`.

Now pstCollectionView.contentSize == uiCollectionView.contentSize, as far as I can tell.
