### PR TITLE
CreatePreparedCellForItem... doesn't apply attributes.

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -1309,6 +1309,9 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
     
     PSTCollectionViewCell *cell = [self.dataSource collectionView:self cellForItemAtIndexPath:indexPath];
     
+    // Apply attributes
+    [cell applyLayoutAttributes: layoutAttributes];
+
     // reset selected/highlight state
     [cell setHighlighted:[_indexPathsForHighlightedItems containsObject:indexPath]];
     [cell setSelected:[_indexPathsForSelectedItems containsObject:indexPath]];


### PR DESCRIPTION
Just a really quick one, not sure if this was intentional (via some convoluted process) or just an oversight, but fixed createPreparedCellForItemAtIndexPath:layoutAttributes: not applying attributes.  This was causing cells to be in strange positions after calling reloadData on the collection view until the user manually scrolls.
