### PR TITLE
Behaviour when layoutAttributesForElementsInRect is nil

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -1243,6 +1243,12 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
 - (void)updateVisibleCellsNow:(BOOL)now {
     NSArray *layoutAttributesArray = [_collectionViewData layoutAttributesForElementsInRect:self.bounds];
     
+    if (layoutAttributesArray == nil || [layoutAttributesArray count] == 0) {
+        // If our layout source isn't providing any layout information, we should just
+        // stop, otherwise we'll blow away all the currently existing cells.
+        return;
+    }
+
     // create ItemKey/Attributes dictionary
     NSMutableDictionary *itemKeysToAddDict = [NSMutableDictionary dictionary];
     for (PSTCollectionViewLayoutAttributes *layoutAttributes in layoutAttributesArray) {


### PR DESCRIPTION
I'm not 100% exactly what the behaviour is with UICollectionView here, but it's much more lazy than what PSTCollectionView does.  I'm sure this small hack isn't the way UICollectionView does it, but it certainly gets the behaviour a lot closer.

Without this hack, if your custom layout returns nil for a given rect, the collection view will go ahead and remove _every_ cell immediately; UICollectionView by comparison, just doesn't update anything.  This is an attempt to replicate that behaviour by cutting it off early.

Sorry about the pull request spam.
