### PR TITLE
Fixed crash in [PSTCollectionView updateWithItems:] oldToNewIndexMap 

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -1529,7 +1529,11 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
     for (PSTCollectionViewItemKey *key in [_allVisibleViewsDict keyEnumerator]) {
         PSTCollectionReusableView *view = _allVisibleViewsDict[key];
         NSInteger oldGlobalIndex = [_update[@"oldModel"] globalIndexForItemAtIndexPath:key.indexPath];
-        NSInteger newGlobalIndex = [_update[@"oldToNewIndexMap"][oldGlobalIndex] intValue];
+		NSArray *oldToNewIndexMap = _update[@"oldToNewIndexMap"];
+        NSInteger newGlobalIndex = NSNotFound;
+		if (oldGlobalIndex >= 0 && oldGlobalIndex < [oldToNewIndexMap count]) {
+			newGlobalIndex = [oldToNewIndexMap[oldGlobalIndex] intValue];
+		}
         NSIndexPath *newIndexPath = newGlobalIndex == NSNotFound ? nil : [_update[@"newModel"] indexPathForItemAtGlobalIndex:newGlobalIndex];
         if (newIndexPath) {
             PSTCollectionViewLayoutAttributes* startAttrs =


### PR DESCRIPTION
The crash happens because index is out of range.

I populate the collectionview using KVO, like this

```
[self.collectionView insertItemsAtIndexPaths:indexPaths];
```

It happened when indexPaths contained 1 element: (row 0, section 0).
