### PR TITLE
Avoiding UIButtons from highlighting

### DIFF
--- a/PSTCollectionView/PSTCollectionViewCell.m
+++ b/PSTCollectionView/PSTCollectionViewCell.m
@@ -165,8 +165,10 @@
     for (id view in subviews) {
         // Ignore the events if view wants to
         if (!((UIView *)view).isUserInteractionEnabled &&
-            [view respondsToSelector:@selector(setHighlighted:)]) {
+            [view respondsToSelector:@selector(setHighlighted:)] &&
+            ![view isKindOfClass:[UIButton class]]) {
             [view setHighlighted:highlighted];
+            
         }
         [self setHighlighted:highlighted forViews:[view subviews]];
     }


### PR DESCRIPTION
UIButtons shouldn't be highlighted when the cell is. This is the default behavior at least. 
That's the only thing I've changed.

Thanks for your great project,
Laurin
