### PR TITLE
Fix typo in setting backgroundView.autoresizingMask

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -961,7 +961,7 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
         [_backgroundView removeFromSuperview];
         _backgroundView = backgroundView;
         backgroundView.frame = (CGRect){.origin=self.contentOffset,.size=self.bounds.size};
-        backgroundView.autoresizesSubviews = UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth;
+        backgroundView.autoresizingMask = UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth;
         [self addSubview:backgroundView];
         [self sendSubviewToBack:backgroundView];
     }


### PR DESCRIPTION
This lvalue looked mis-autocorrected.
