### PR TITLE
Fix compilation without UIKit in a prefix header

### DIFF
--- a/PSTCollectionView/NSIndexPath+PSTCollectionViewAdditions.h
+++ b/PSTCollectionView/NSIndexPath+PSTCollectionViewAdditions.h
@@ -1,0 +1,17 @@
+//
+//  NSIndexPath+PSTCollectionViewAdditions.h
+//  PSTCollectionView
+//
+//  Copyright (c) 2013 Peter Steinberger. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+
+@interface NSIndexPath (PSTCollectionViewAdditions)
+
++ (NSIndexPath *)indexPathForItem:(NSInteger)item inSection:(NSInteger)section;
+
+- (NSInteger)item;
+
+@end

--- a/PSTCollectionView/NSIndexPath+PSTCollectionViewAdditions.m
+++ b/PSTCollectionView/NSIndexPath+PSTCollectionViewAdditions.m
@@ -1,0 +1,26 @@
+//
+//  NSIndexPath+PSTCollectionViewAdditions.m
+//  PSTCollectionView
+//
+//  Copyright (c) 2013 Peter Steinberger. All rights reserved.
+//
+
+#import "NSIndexPath+PSTCollectionViewAdditions.h"
+
+
+@implementation NSIndexPath (PSTCollectionViewAdditions)
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < 60000
+
+// Simple NSIndexPath addition to allow using "item" instead of "row".
++ (NSIndexPath *)indexPathForItem:(NSInteger)item inSection:(NSInteger)section {
+    return [NSIndexPath indexPathForRow:item inSection:section];
+}
+
+- (NSInteger)item {
+    return self.row;
+}
+
+#endif
+
+@end

--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -1988,20 +1988,6 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
 
 @end
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < 60000
-@implementation NSIndexPath (PSTCollectionViewAdditions)
-
-// Simple NSIndexPath addition to allow using "item" instead of "row".
-+ (NSIndexPath *)indexPathForItem:(NSInteger)item inSection:(NSInteger)section {
-    return [NSIndexPath indexPathForRow:item inSection:section];
-}
-
-- (NSInteger)item {
-    return self.row;
-}
-@end
-#endif
-
 ///////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - Runtime Additions to create UICollectionView
 

--- a/PSTCollectionView/PSTCollectionViewUpdateItem.m
+++ b/PSTCollectionView/PSTCollectionViewUpdateItem.m
@@ -8,6 +8,9 @@
 
 #import "PSTCollectionViewUpdateItem.h"
 
+#import "NSIndexPath+PSTCollectionViewAdditions.h"
+
+
 @interface PSTCollectionViewUpdateItem() {
     NSIndexPath *_initialIndexPath;
     NSIndexPath *_finalIndexPath;

--- a/PSTCollectionView/PSTGridLayoutInfo.h
+++ b/PSTCollectionView/PSTGridLayoutInfo.h
@@ -5,7 +5,7 @@
 //  Copyright (c) 2012-2013 Peter Steinberger. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @class PSTGridLayoutSection;
 

--- a/PSTCollectionView/PSTGridLayoutItem.h
+++ b/PSTCollectionView/PSTGridLayoutItem.h
@@ -5,7 +5,7 @@
 //  Copyright (c) 2012-2013 Peter Steinberger. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @class PSTGridLayoutSection, PSTGridLayoutRow;
 

--- a/PSTCollectionView/PSTGridLayoutRow.h
+++ b/PSTCollectionView/PSTGridLayoutRow.h
@@ -5,7 +5,7 @@
 //  Copyright (c) 2012-2013 Peter Steinberger. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @class PSTGridLayoutSection, PSTGridLayoutItem;
 

--- a/PSTCollectionView/PSTGridLayoutSection.h
+++ b/PSTCollectionView/PSTGridLayoutSection.h
@@ -5,7 +5,7 @@
 //  Copyright (c) 2012-2013 Peter Steinberger. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @class PSTGridLayoutInfo, PSTGridLayoutRow, PSTGridLayoutItem;
 


### PR DESCRIPTION
For personal reasons, my project does not include `UIKit.h` in a prefix header.
This changeset allows compilation of PSTCollectionView in that environment.
