### PR TITLE
non-visible cell remains selected after deselect

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -852,11 +852,11 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
             if (selectedCell.selected) {
                 selectedCell.selected = NO;
             }
-            [_indexPathsForSelectedItems removeObject:indexPath];
-                
-            if (notifyDelegate && _collectionViewFlags.delegateDidDeselectItemAtIndexPath) {
-                [self.delegate collectionView:self didDeselectItemAtIndexPath:indexPath];
-            }
+        }
+        [_indexPathsForSelectedItems removeObject:indexPath];
+            
+        if (notifyDelegate && _collectionViewFlags.delegateDidDeselectItemAtIndexPath) {
+            [self.delegate collectionView:self didDeselectItemAtIndexPath:indexPath];
         }
     }
 }


### PR DESCRIPTION
Fixed bug where non-visible cell remains selected after calling deselect.
