### PR TITLE
Fix inconsistency with UICollectionView's performBatchUpdates:completion: behaviour

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -949,11 +949,9 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
 }
 
 - (void)performBatchUpdates:(void (^)(void))updates completion:(void (^)(BOOL finished))completion {
-    if(!updates) return;
-    
     [self setupCellAnimations];
     
-    updates();
+    if(updates) updates();
     
     if(completion) _updateCompletionHandler = completion;
     


### PR DESCRIPTION
When `UICollectionViews`'s `performBatchUpdates:completion` is called with `nil` for each of the block parameters, the view still animates any changes to the layout (as suggested here http://stackoverflow.com/questions/12999510/uicollectionview-animation-custom-layout). The early return from `PSTCollectionView`'s corresponding method meant that it behaved differently, this change fixes that.
