### PR TITLE
Add filter for cell layoutAttributes

### DIFF
--- a/PSTCollectionView/PSTCollectionViewData.m
+++ b/PSTCollectionView/PSTCollectionViewData.m
@@ -90,7 +90,10 @@
     // TODO: check if we need to fetch data from layout
     if (!CGRectEqualToRect(_validLayoutRect, rect)) {
         _validLayoutRect = rect;
-        _cellLayoutAttributes = [self.layout layoutAttributesForElementsInRect:rect];
+        // we only want cell layoutAttributes
+        _cellLayoutAttributes = [[self.layout layoutAttributesForElementsInRect:rect] filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(PSTCollectionViewLayoutAttributes *evaluatedObject, NSDictionary *bindings) {
+            return ([evaluatedObject isKindOfClass:[PSTCollectionViewLayoutAttributes class]] && [evaluatedObject isCell]);
+        }]];
     }
 }
 


### PR DESCRIPTION
In -[prepareForCollectionViewUpdates: prepareForCollectionViewUpdates:] the layoutAttributes for the footer accessory view were collected into _finalAnimationLayoutAttributesDict. This results in an -[NSArray addObject: nil] in -[PSTCollectionView indexPathsForVisibleItems] for a cell with no layoutAttributes.

By filtering the layoutAttributes in -[PSTCollectionViewData validateLayoutInRect:] to just the cell attributes we get the expected behavior.

(This might not be the best place for this check...)
