### PR TITLE
fix condition for layout invalidation

### DIFF
--- a/PSTCollectionView/PSTCollectionViewFlowLayout.m
+++ b/PSTCollectionView/PSTCollectionViewFlowLayout.m
@@ -251,7 +251,7 @@ static char kPSTCachedItemRectsKey;
 
 - (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds {
     // we need to recalculate on width changes
-    if ((self.collectionView.bounds.size.width != newBounds.size.width && self.scrollDirection == PSTCollectionViewScrollDirectionHorizontal) || (self.collectionView.bounds.size.height != newBounds.size.height && self.scrollDirection == PSTCollectionViewScrollDirectionVertical)) {
+    if ((self.collectionView.bounds.size.width != newBounds.size.width && self.scrollDirection == PSTCollectionViewScrollDirectionVertical) || (self.collectionView.bounds.size.height != newBounds.size.height && self.scrollDirection == PSTCollectionViewScrollDirectionHorizontal)) {
         return YES;
     }
     return NO;


### PR DESCRIPTION
Default flow layout (PSTCollectionViewFlowLayout) won't invalidate its layout when it should: e.g., changing the width of the view the layout should be invalidated if the scroll direction is PSTCollectionViewScrollDirectionVertical, but not if it is PSTCollectionViewScrollDirectionHorizontal and vice versa.
