### PR TITLE
Only apply cell attrs to cells

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -1601,7 +1601,7 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
     for (PSTCollectionViewLayoutAttributes *attrs in allNewlyVisibleItems) {
         PSTCollectionViewItemKey *key = [PSTCollectionViewItemKey collectionItemKeyForLayoutAttributes:attrs];
         
-        if (![[newAllVisibleView allKeys] containsObject:key]) {
+        if (key.type == PSTCollectionViewItemTypeCell && ![[newAllVisibleView allKeys] containsObject:key]) {
             PSTCollectionViewLayoutAttributes* startAttrs =
             [_layout initialLayoutAttributesForAppearingItemAtIndexPath:attrs.indexPath];
             


### PR DESCRIPTION
If a footer attr is applied to a cell, sometimes we get a duplicate cell, sometimes we crash, neither is desirable.

This is a better fix than https://github.com/educreations/PSTCollectionView/commit/838ec5e3133e90bce53e0872c678536b29247c74 which stopped working with https://github.com/scutdavy/PSTCollectionView/commit/a73d901ae707571bd6f3a3b2f884ef27fafc6e11
