### PR TITLE
Remove unused gesture recognizer.

### DIFF
--- a/Examples/Basic/ViewController.m
+++ b/Examples/Basic/ViewController.m
@@ -13,8 +13,6 @@
 - (void)viewDidLoad {
 	[super viewDidLoad];
 	
-    UIPinchGestureRecognizer* pinchRecognizer = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(handlePinchGesture:)];
-    [self.collectionView addGestureRecognizer:pinchRecognizer];
     [self.collectionView registerClass:[Cell class] forCellWithReuseIdentifier:@"MY_CELL"];
 }
 


### PR DESCRIPTION
The selector doesn't exist on the target, so a crash happens if the pinch is actually used.
