### PR TITLE
Cells are not added in the same order as layoutAttributesArray

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -1319,9 +1319,9 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
     }
     
     // finally add new cells.
-    [itemKeysToAddDict enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-        PSTCollectionViewItemKey *itemKey = key;
-        PSTCollectionViewLayoutAttributes *layoutAttributes = obj;
+    for (PSTCollectionViewLayoutAttributes *layoutAttributes in layoutAttributesArray) {
+        PSTCollectionViewItemKey *itemKey = [PSTCollectionViewItemKey collectionItemKeyForLayoutAttributes:layoutAttributes];
+        itemKeysToAddDict[itemKey] = layoutAttributes;
         
         // check if cell is in visible dict; add it if not.
         PSTCollectionReusableView *view = _allVisibleViewsDict[itemKey];
@@ -1339,7 +1339,7 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
 			if (view) {
 				_allVisibleViewsDict[itemKey] = view;
 				[self addControlledSubview:view];
-
+                
                 // Always apply attributes. Fixes #203.
                 [view applyLayoutAttributes:layoutAttributes];
 			}
@@ -1347,7 +1347,7 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
             // just update cell
             [view applyLayoutAttributes:layoutAttributes];
         }
-    }];
+    }
 }
 
 // fetches a cell from the dataSource and sets the layoutAttributes


### PR DESCRIPTION
The standard UICollectionViewController implementation adds cells beginning in the top-left and ending in the bottom-right. In PSTCollectionView, the cells are added in the order defined by `itemKeysToAddDict enumerateKeysAndObjectsUsingBlock` in [PSTCollectionView.m](https://github.com/steipete/PSTCollectionView/blob/master/PSTCollectionView/PSTCollectionView.m#L1322), hence no particular order.

While this isn't so much of a problem for fast loading resources, the order becomes more important when sequential loading of images is employed.

This pull request iterates through `layoutAttributes` instead of enumerating `itemKeysToAddDict`, therefore preserving the order.
