### PR TITLE
Fixes issue where Cells are Missing after updateVisibleCellsNow

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -1406,8 +1406,10 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
 
 - (void)addControlledSubview:(PSTCollectionReusableView *)subview {
     // avoids placing views above the scroll indicator
-	NSInteger insertionIndex = (NSInteger)(self.subviews.count - (self.dragging ? 1 : 0));
-    [self insertSubview:subview atIndex:(insertionIndex < 0 ? 0 : insertionIndex)];
+	// If the collection view is not displaying scrollIndicators then self.subviews.count can be 0.
+	// We take the max to ensure we insert at a non negative index because a negative index will silently fail to insert the view
+	NSInteger insertionIndex = MAX((NSInteger)(self.subviews.count - (self.dragging ? 1 : 0)), 0);
+    [self insertSubview:subview atIndex:insertionIndex];
     UIView *scrollIndicatorView = nil;
     if (self.dragging) {
         scrollIndicatorView = [self.subviews lastObject];


### PR DESCRIPTION
In some cases where the cells are sufficiently large and `showsHorizontalScrollIndicator` and `showsVerticalScrollIndicator` are both `NO` the number of subviews becomes zero. If this happens and `self.dragging` is `YES` then we are trying to insert the cell at a negative index which will not add the subview. Any subsequent insertion will also fail since the number of subviews will still be zero. This fix ensures that we insert the cell at a non-negative index.
