### PR TITLE
Fix stack overflow caused when a PSTCollectionView is its own delegate

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -1188,7 +1188,9 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
 }
 
 - (void)setDelegate:(id<PSTCollectionViewDelegate>)delegate {
-	self.extVars.collectionViewDelegate = delegate;
+    if (self.extVars.collectionViewDelegate != (id)self) {
+        self.extVars.collectionViewDelegate = delegate;
+    }
     
 	//	Managing the Selected Cells
 	_collectionViewFlags.delegateShouldSelectItemAtIndexPath       = [self.delegate respondsToSelector:@selector(collectionView:shouldSelectItemAtIndexPath:)];


### PR DESCRIPTION
Solution proposed in Issue 241:
https://github.com/steipete/PSTCollectionView/issues/241
