### PR TITLE
Force layoutSubviews when calling -(void)reloadData

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -529,7 +529,7 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
     [_indexPathsForSelectedItems removeAllObjects];
     [_indexPathsForHighlightedItems removeAllObjects];
 
-    [self setNeedsLayout];
+    [self layoutSubviews];
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I have noticed that if I call:

<pre>[self.collectionView reloadData];
[self.collectionView scrollRectToVisible:CGRectInfinite animated:NO];</pre>


the view does not scroll to the end of the bounds. However, if `layoutSubviews` is called instead of `setNeedsLayout` when reloading data, the above code works.
