### PR TITLE
PSTCollectionElementCategory and layout subclassing

### DIFF
--- a/PSTCollectionView/PSTCollectionView.h
+++ b/PSTCollectionView/PSTCollectionView.h
@@ -28,6 +28,12 @@ typedef NS_OPTIONS(NSUInteger, PSTCollectionViewScrollPosition) {
     PSTCollectionViewScrollPositionRight                = 1 << 5
 };
 
+typedef NS_ENUM(NSUInteger, PSTCollectionElementCategory) {
+    PSTCollectionElementCategoryCell,
+    PSTCollectionElementCategorySupplementaryView,
+    PSTCollectionElementCategoryDecorationView
+};
+
 /**
  Replacement for UICollectionView for iOS4/5.
  Only supports a subset of the features of UICollectionView.

--- a/PSTCollectionView/PSTCollectionViewFlowLayout.h
+++ b/PSTCollectionView/PSTCollectionViewFlowLayout.h
@@ -24,6 +24,7 @@ typedef NS_ENUM(NSInteger, PSTCollectionViewScrollDirection) {
 - (CGFloat)collectionView:(PSTCollectionView *)collectionView layout:(PSTCollectionViewLayout*)collectionViewLayout minimumInteritemSpacingForSectionAtIndex:(NSInteger)section;
 - (CGSize)collectionView:(PSTCollectionView *)collectionView layout:(PSTCollectionViewLayout*)collectionViewLayout referenceSizeForHeaderInSection:(NSInteger)section;
 - (CGSize)collectionView:(PSTCollectionView *)collectionView layout:(PSTCollectionViewLayout*)collectionViewLayout referenceSizeForFooterInSection:(NSInteger)section;
+- (PSTCollectionViewLayoutAttributes *)layoutAttributesForSupplementaryViewOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath;
 
 @end
 
@@ -104,7 +105,6 @@ typedef NS_ENUM(NSInteger, PSTFlowLayoutHorizontalAlignment) {
 - (PSTCollectionViewLayoutAttributes *)_layoutAttributesForItemsInRect:(CGRect)arg1;
 - (CGSize)collectionViewContentSize;
 - (void)finalizeCollectionViewUpdates;
-- (PSTCollectionViewLayoutAttributes *)layoutAttributesForSupplementaryViewOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath;
 - (void)_invalidateButKeepDelegateInfo;
 - (void)_invalidateButKeepAllInfo;
 - (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)arg1;


### PR DESCRIPTION
I implemented a layout subclass that required `- (PSTCollectionViewLayoutAttributes *)layoutAttributesForSupplementaryViewOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath;` so I moved it public because it is public in `UICollectionViewLayoutAttributes`.

http://developer.apple.com/library/ios/#documentation/uikit/reference/UICollectionViewLayoutAttributes_class/Reference/Reference.html

These changes also fix #243
