### PR TITLE
Revert delegate setting related commits

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -1220,12 +1220,8 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
 }
 
 - (void)setDelegate:(id<PSTCollectionViewDelegate>)delegate {
-    // We capture the delegate to get access to certain UIScrollView events.
-    // That's not needed when we are our own delegate (as long as parent behaves and properly calls super)
-    if (self.extVars.collectionViewDelegate != (id)self) {
-        self.extVars.collectionViewDelegate = delegate;
-    }
-
+	self.extVars.collectionViewDelegate = delegate;
+    
 	//	Managing the Selected Cells
 	_collectionViewFlags.delegateShouldSelectItemAtIndexPath       = [self.delegate respondsToSelector:@selector(collectionView:shouldSelectItemAtIndexPath:)];
 	_collectionViewFlags.delegateDidSelectItemAtIndexPath          = [self.delegate respondsToSelector:@selector(collectionView:didSelectItemAtIndexPath:)];


### PR DESCRIPTION
This reverts the following commits:
- efc4f9948db0a89435627bde32d2232efc04d020 (modify delegate setting)
- bca811fc9618236c937d3945834d81201a7080ed (comment on the modification
  that was made)

As it turns out, this is:
1. A typo (it should check if `self != nil`)
2. Not setting `extVars.collectionViewDelegate` when `== self` is not the right solution, since it blocks calls to `PSTCollectionView`'s functional implementation of UIScrollViewDelegate methods (such as `scrollViewDidEndDragging:willDecelerate:`)

As I said in #251, I'm going to try to use an instance of `HTDelegateProxy` and remove `PSTCollectionView`'s UIScrollViewDelegate method forwarding.  Perhaps Apple is using something similar to `HTDelegateProxy` to forward invocations, while avoiding the callback loop.
