### PR TITLE
Applied the transform to the collection view cell's frame

### DIFF
--- a/PSTCollectionView/PSTCollectionViewCell.m
+++ b/PSTCollectionView/PSTCollectionViewCell.m
@@ -54,7 +54,7 @@
     if (layoutAttributes != _layoutAttributes) {
         _layoutAttributes = layoutAttributes;
 
-        self.frame = layoutAttributes.frame;
+        self.frame = CGRectApplyAffineTransform(layoutAttributes.frame, CATransform3DGetAffineTransform(layoutAttributes.transform3D));
         self.center = layoutAttributes.center;
 
         self.hidden = layoutAttributes.isHidden;


### PR DESCRIPTION
In the WWDC 2012 videos there's a lecture about advanced layouts. One of them shows how to zoom in the central cell, and we're using the code from this lecture in one of our apps. This code works fine on iOS 6 but not on iOS 5.

The main issue was that applying the attribute's frame to the cell's frame and the attribute's transform to the cell's transform was insufficient. The frame had to be transformed before being set. This is a one line fix (the best kind) so it should be pretty obvious what I'm doing. I've tried this on a small test project and on our main project and it works perfectly.

Unfortunately there's more to this issue regarding which layout methods are being called, but I didn't want to touch this for now. I'll open an issue for it and maybe somebody can get to it at some point.
