### PR TITLE
Implement -layoutAttributesForDecorationViewOfKind:…

### DIFF
--- a/PSTCollectionView/PSTCollectionViewLayout.m
+++ b/PSTCollectionView/PSTCollectionViewLayout.m
@@ -277,7 +277,7 @@
     return nil;
 }
 
-- (PSTCollectionViewLayoutAttributes *)layoutAttributesForDecorationViewWithReuseIdentifier:(NSString*)identifier atIndexPath:(NSIndexPath *)indexPath {
+- (PSTCollectionViewLayoutAttributes *)layoutAttributesForDecorationViewOfKind:(NSString*)kind atIndexPath:(NSIndexPath *)indexPath {
     return nil;
 }
 


### PR DESCRIPTION
I missed the default implementation when correcting the selector name from `…WithReuseIdentifier:…` to `…OfKind:…`.
