### PR TITLE
Grid Layout Row Snapping Fix

### DIFF
--- a/PSTCollectionView/PSTGridLayoutRow.m
+++ b/PSTCollectionView/PSTGridLayoutRow.m
@@ -149,8 +149,8 @@
                     itemOffset.x += interSpacing;
                 }
             }
-            item.itemFrame = CGRectIntegral(itemFrame); // might call nil; don't care
-            [rects addObject:[NSValue valueWithCGRect:CGRectIntegral(itemFrame)]];
+            item.itemFrame = itemFrame; // might call nil; don't care
+            [rects addObject:[NSValue valueWithCGRect:itemFrame]];
             frame = CGRectUnion(frame, itemFrame);
         }
         _rowSize = frame.size;


### PR DESCRIPTION
This makes it so the grid no longer forces the rects to be on integer boundaries this is closer to the native collection view behavior. 
