### PR TITLE
fix a typo which prevents _moveItems being created

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -1500,7 +1500,7 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
             ret = _deleteItems;
             break;
         case PSTCollectionUpdateActionMove:
-            if (_moveItems)      _moveItems = [[NSMutableArray alloc] init];
+            if (!_moveItems)      _moveItems = [[NSMutableArray alloc] init];
             ret = _moveItems;
             break;
         case PSTCollectionUpdateActionReload:


### PR DESCRIPTION
fix a typo which prevents _moveItems being created
