### PR TITLE
Fix for Issue: #276 - encodeWithCoder:(NSCoder *)coder in PSTCollectionViewFlowLayout is not implemented

### DIFF
--- a/PSTCollectionView/PSTCollectionViewFlowLayout.m
+++ b/PSTCollectionView/PSTCollectionViewFlowLayout.m
@@ -113,6 +113,19 @@ NSString *const PSTFlowLayoutRowVerticalAlignmentKey = @"UIFlowLayoutRowVertical
     return self;
 }
 
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+    [super encodeWithCoder:coder];
+    
+    [coder encodeCGSize:self.itemSize forKey:@"UIItemSize"];
+    [coder encodeFloat:self.minimumInteritemSpacing forKey:@"UIInteritemSpacing"];
+    [coder encodeFloat:self.minimumLineSpacing forKey:@"UILineSpacing"];
+    [coder encodeCGSize:self.footerReferenceSize forKey:@"UIFooterReferenceSize"];
+    [coder encodeCGSize:self.headerReferenceSize forKey:@"UIHeaderReferenceSize"];
+    [coder encodeUIEdgeInsets:self.sectionInset forKey:@"UISectionInset"];
+    [coder encodeInteger:self.scrollDirection forKey:@"UIScrollDirection"];
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - PSTCollectionViewLayout
 


### PR DESCRIPTION
- (void)encodeWithCoder:(NSCoder *)coder
  Writes out the same keys that are used in initFromCoder.  This fixes an issue where if the flow layout was serialized and then deserialized it wouldn't
  contain the original values.
