### PR TITLE
Fix a few typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you always want to use PSTCollectionView, use PSTCollectionView as class name
 ## Current State
 
 Most features work, including the flow layout with fixed or dynamic cell sizes and supplementary views. If you're not doing something fancy, it should just work.
-PSTCollectionView is also internally designed very closesly to UICollectionView and thus a great study if you're wondering how UICollectionView works. See [HowTo](/steipete/PSTCollectionView/blob/master/HowTo.md) for helpful details.
+PSTCollectionView is also internally designed very closely to UICollectionView and thus a great study if you're wondering how UICollectionView works. See [HowTo](HowTo.md) for helpful details.
 
 ## How can I help?
 
@@ -20,7 +20,7 @@ The best way is if you're already using UICollectionView somewhere. Add PSTColle
 
 Or start playing around with one of the WWDC examples and try to make them work with PSTCollectionView. Most of them already do, but just not as perfect.
 
-You could also write a Pintrest-style layout manager. Can't be that hard.
+You could also write a Pinterest-style layout manager. Can't be that hard.
 
 ## Animations
 
@@ -36,7 +36,7 @@ PSTCollectionView needs the QuartzCore.framework.
 
 ## Interoperability
 
-Another goal (at least super useful for debugging) is interoperability between UI/PS classes:
+Another goal (at least super useful for debugging) is interoperability between UI/PST classes:
 
 ``` objective-c
 UICollectionViewFlowLayout *flowLayout = [UICollectionViewFlowLayout new];


### PR DESCRIPTION
I noticed that the link to the `HowTo.md` file was broken and wanted to fix it, and then I've changed a few more characters around here and there :)
