### PR TITLE
Fix -[PSTCollectionViewCell applyLayoutAttributes:] (hopefully)

### DIFF
--- a/PSTCollectionView/PSTCollectionViewCell.m
+++ b/PSTCollectionView/PSTCollectionViewCell.m
@@ -54,14 +54,12 @@
     if (layoutAttributes != _layoutAttributes) {
         _layoutAttributes = layoutAttributes;
 
-        self.frame = CGRectApplyAffineTransform(layoutAttributes.frame, CATransform3DGetAffineTransform(layoutAttributes.transform3D));
+        self.bounds = (CGRect){ .origin = self.bounds.origin, .size = layoutAttributes.size };
         self.center = layoutAttributes.center;
-
-        self.hidden = layoutAttributes.isHidden;
+        self.hidden = layoutAttributes.hidden;
         self.layer.transform = layoutAttributes.transform3D;
         self.layer.zPosition = layoutAttributes.zIndex;
         self.layer.opacity = layoutAttributes.alpha;
-        // TODO more attributes
     }
 }
 


### PR DESCRIPTION
In our app, we have implemented `finalLayoutAttributesForDisappearingItemAtIndexPath:` to discard deleted cells with a rotation & translation. These animations broke when we upgraded to PSTCollectionView 1.0.0 recently. I have been able to track it down to this commit: https://github.com/steipete/PSTCollectionView/pull/263

This commit has indeed fixed the LineLayout example where cells are scaled, but at the cost of breaking rotations. This can be observed in the LineLayout example by changing the method `-[LineLayout layoutAttributesForElementsInRect:]`, replacing this line:

```
attributes.transform3D = CATransform3DMakeScale(zoom, zoom, 1.0);
```

...by a rotation:

```
attributes.transform3D = CATransform3DMakeRotation(zoom - 1, 0.0, 0.0, 1.0);
```

The result is distorted on iOS 5 because the `CGRectApplyAffineTransform` function changes the size of the cell when it should have the same area, just with a rotation applied.

I think changing the `bounds` rect is the way to go - this works in the LineLayout example (with and without the modification above), in our app, and has not broken any of the other examples as far as I could see.

As an added bonus, `PSTCollectionViewCell` transforms are not limited to affine transforms now :)

And once again, thanks for the legendary library!
