### PR TITLE
Fixes a crash when setting up a unit test environment

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -2249,13 +2249,36 @@ __attribute__((constructor)) static void PSTCreateUICollectionViewClasses(void) 
 
         // add PSUI classes at runtime to make Interface Builder sane
         // (IB doesn't allow adding the PSUICollectionView_ types but doesn't complain on unknown classes)
-        objc_registerClassPair(objc_allocateClassPair([PSUICollectionView_ class], "PSUICollectionView", 0));
-        objc_registerClassPair(objc_allocateClassPair([PSUICollectionViewCell_ class], "PSUICollectionViewCell", 0));
-        objc_registerClassPair(objc_allocateClassPair([PSUICollectionReusableView_ class], "PSUICollectionReusableView", 0));
-        objc_registerClassPair(objc_allocateClassPair([PSUICollectionViewLayout_ class], "PSUICollectionViewLayout", 0));
-        objc_registerClassPair(objc_allocateClassPair([PSUICollectionViewFlowLayout_ class], "PSUICollectionViewFlowLayout", 0));
-        objc_registerClassPair(objc_allocateClassPair([PSUICollectionViewLayoutAttributes_ class], "PSUICollectionViewLayoutAttributes", 0));
-        objc_registerClassPair(objc_allocateClassPair([PSUICollectionViewController_ class], "PSUICollectionViewController", 0));
+		Class theClass = objc_allocateClassPair([PSUICollectionView_ class], "PSUICollectionView", 0);
+		if (theClass) {
+			objc_registerClassPair(theClass);
+		} else {
+			// Do nothing. The class name is already in use. This may happen if this code is running for the second time (first for an app bundle, then again for a unit test bundle).
+		}
+		theClass = objc_allocateClassPair([PSUICollectionViewCell_ class], "PSUICollectionViewCell", 0);
+		if (theClass) {
+			objc_registerClassPair(theClass);
+		}
+        theClass = objc_allocateClassPair([PSUICollectionReusableView_ class], "PSUICollectionReusableView", 0);
+		if (theClass) {
+			objc_registerClassPair(theClass);
+		}
+        theClass = objc_allocateClassPair([PSUICollectionViewLayout_ class], "PSUICollectionViewLayout", 0);
+		if (theClass) {
+			objc_registerClassPair(theClass);
+		}
+        theClass = objc_allocateClassPair([PSUICollectionViewFlowLayout_ class], "PSUICollectionViewFlowLayout", 0);
+		if (theClass) {
+			objc_registerClassPair(theClass);
+		}
+		theClass = objc_allocateClassPair([PSUICollectionViewLayoutAttributes_ class], "PSUICollectionViewLayoutAttributes", 0);
+        if (theClass) {
+			objc_registerClassPair(theClass);
+		}
+		theClass = objc_allocateClassPair([PSUICollectionViewController_ class], "PSUICollectionViewController", 0);
+		if (theClass) {
+			objc_registerClassPair(theClass);
+		}
     }
 }
 


### PR DESCRIPTION
Hi Peter,
We had a crash when executing our unit tests. Everything is fine while the app bundle is started, but starting the unit test bundle crashes. We fixed it by checking whether the class pairs already exist before registering them. The problem is that
objc_allocateClassPair returns nil if the class pair already exists, and calling objc_registerClassPair with a nil argument causes an EXC_BAD_ACCESS.

Oh, and thanks a ton for the great work! :-)
