### PR TITLE
DecorationView "kind" identifiers are ignored

### DIFF
--- a/PSTCollectionView/PSTCollectionViewItemKey.m
+++ b/PSTCollectionView/PSTCollectionViewItemKey.m
@@ -26,8 +26,17 @@ NSString *const PSTCollectionElementKindDecorationView = @"PSTCollectionElementK
 + (id)collectionItemKeyForLayoutAttributes:(PSTCollectionViewLayoutAttributes *)layoutAttributes {
     PSTCollectionViewItemKey *key = [[self class] new];
     key.indexPath = layoutAttributes.indexPath;
-    key.type = layoutAttributes.representedElementCategory;
-    key.identifier = layoutAttributes.representedElementKind;
+	PSTCollectionViewItemType const itemType = layoutAttributes.representedElementCategory;
+	key.type = itemType;
+	switch (itemType) {
+		case PSTCollectionViewItemTypeCell:
+		case PSTCollectionViewItemTypeSupplementaryView:
+			key.identifier = layoutAttributes.representedElementKind;
+			break;
+		case PSTCollectionViewItemTypeDecorationView:
+			key.identifier = layoutAttributes.reuseIdentifier;
+			break;
+	}
     return key;
 }
 


### PR DESCRIPTION
Decoration view identifiers are ignored when calculating layout attributes, resulting in one of the defined views "winning".

See testcase:
https://github.com/cysp/PSTCollectionView/tree/testcase/decorationview-layout
(Change the indexPath for either of the decoration views to see the expected behaviour.)
