### PR TITLE
Lazy load the collection view for registering cells at init

### DIFF
--- a/PSTCollectionView/PSTCollectionViewController.m
+++ b/PSTCollectionView/PSTCollectionViewController.m
@@ -100,6 +100,18 @@
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - Lazy load the collection view
+
+- (PSTCollectionView *)collectionView {
+    if (!_collectionView) {
+        _collectionView = [[PSTCollectionView alloc] initWithFrame:[[UIScreen mainScreen] bounds] collectionViewLayout:self.layout];
+        _collectionView.delegate = self;
+        _collectionView.dataSource = self;
+    }
+    return _collectionView;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - Properties
 
 - (void)setClearsSelectionOnViewWillAppear:(BOOL)clearsSelectionOnViewWillAppear {


### PR DESCRIPTION
If you want to register cell NIBs/classes in the init method of a PSTCollectionViewController subclass, then it doesn't work because self.collectionView is nil at that point. This fixes that by lazy loading it.
