### PR TITLE
Fix to issue 317

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -1182,7 +1182,7 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
                 PSTCollectionReusableView *view = _allVisibleViewsDict[key];
                 if (!view) {
                     PSTCollectionViewLayoutAttributes *attrs = layoutInterchangeData[key][@"previousLayoutInfos"];
-                    view = [self dequeueReusableOrCreateDecorationViewOfKind:attrs.reuseIdentifier forIndexPath:attrs.indexPath];
+                    view = [self dequeueReusableOrCreateDecorationViewOfKind:attrs.representedElementKind forIndexPath:attrs.indexPath];
                     _allVisibleViewsDict[key] = view;
                     [self addControlledSubview:view];
                 }
@@ -1377,7 +1377,7 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
 																 atIndexPath:layoutAttributes.indexPath
 														withLayoutAttributes:layoutAttributes];
 			} else if (itemKey.type == PSTCollectionViewItemTypeDecorationView) {
-				view = [self dequeueReusableOrCreateDecorationViewOfKind:layoutAttributes.reuseIdentifier forIndexPath:layoutAttributes.indexPath];
+				view = [self dequeueReusableOrCreateDecorationViewOfKind:layoutAttributes.representedElementKind forIndexPath:layoutAttributes.indexPath];
 			}
 
 			// Supplementary views are optional

--- a/PSTCollectionView/PSTCollectionViewLayout.m
+++ b/PSTCollectionView/PSTCollectionViewLayout.m
@@ -34,6 +34,7 @@
     } _layoutFlags;
 }
 @property (nonatomic, copy) NSString *elementKind;
+@property (nonatomic) PSTCollectionViewItemType elementCategory;
 @property (nonatomic, copy) NSString *reuseIdentifier;
 @end
 
@@ -49,6 +50,7 @@
 + (instancetype)layoutAttributesForCellWithIndexPath:(NSIndexPath *)indexPath {
     PSTCollectionViewLayoutAttributes *attributes = [self new];
     attributes.elementKind = PSTCollectionElementKindCell;
+    attributes.elementCategory = PSTCollectionViewItemTypeCell;
     attributes.indexPath = indexPath;
     return attributes;
 }
@@ -56,6 +58,7 @@
 + (instancetype)layoutAttributesForSupplementaryViewOfKind:(NSString *)elementKind withIndexPath:(NSIndexPath *)indexPath {
     PSTCollectionViewLayoutAttributes *attributes = [self new];
     attributes.elementKind = elementKind;
+    attributes.elementCategory = PSTCollectionViewItemTypeSupplementaryView;
     attributes.indexPath = indexPath;
     return attributes;
 }
@@ -63,6 +66,7 @@
 + (instancetype)layoutAttributesForDecorationViewOfKind:(NSString *)kind withIndexPath:(NSIndexPath *)indexPath {
     PSTCollectionViewLayoutAttributes *attributes = [self new];
     attributes.elementKind = kind;
+    attributes.elementCategory = PSTCollectionViewItemTypeDecorationView;
     attributes.indexPath = indexPath;
     return attributes;
 }
@@ -100,13 +104,7 @@
 #pragma mark - Public
 
 - (PSTCollectionViewItemType)representedElementCategory {
-    if ([self.elementKind isEqualToString:PSTCollectionElementKindCell]) {
-        return PSTCollectionViewItemTypeCell;
-    }else if([self.elementKind isEqualToString:PSTCollectionElementKindDecorationView]) {
-        return PSTCollectionViewItemTypeDecorationView;
-    }else {
-        return PSTCollectionViewItemTypeSupplementaryView;
-    }
+    return self.elementCategory;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
PSTCollectionViewLayout layoutAttributesForDecorationViewOfKind:indexPath: will now use kind parameter to set layoutAttributes elementKind property.

Also removed setting of the reuseIdentifier in this method because that may not necessarily match the elementKind.

Filed issue:
https://github.com/steipete/PSTCollectionView/issues/317
