### PR TITLE
If the layout isn't prepared, then prepare it when it's about to be used

### DIFF
--- a/PSTCollectionView/PSTCollectionViewFlowLayout.m
+++ b/PSTCollectionView/PSTCollectionViewFlowLayout.m
@@ -132,7 +132,11 @@ static char kPSTCachedItemRectsKey;
 
 - (NSArray *)layoutAttributesForElementsInRect:(CGRect)rect {
     // Apple calls _layoutAttributesForItemsInRect
-
+    
+    if (!_data) {
+        [self prepareLayout];
+    }
+    
     NSMutableArray *layoutAttributesArray = [NSMutableArray array];
     for (PSTGridLayoutSection *section in _data.sections) {
         if (CGRectIntersectsRect(section.frame, rect)) {
@@ -198,6 +202,10 @@ static char kPSTCachedItemRectsKey;
 }
 
 - (PSTCollectionViewLayoutAttributes *)layoutAttributesForItemAtIndexPath:(NSIndexPath *)indexPath {
+    if (!_data) {
+        [self prepareLayout];
+    }
+    
     PSTGridLayoutSection *section = _data.sections[indexPath.section];
     PSTGridLayoutRow *row = nil;
     CGRect itemFrame = CGRectZero;
@@ -225,6 +233,10 @@ static char kPSTCachedItemRectsKey;
 }
 
 - (PSTCollectionViewLayoutAttributes *)layoutAttributesForSupplementaryViewOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath {
+    if (!_data) {
+        [self prepareLayout];
+    }
+    
     NSUInteger sectionIndex = indexPath.section;
 
     PSTCollectionViewLayoutAttributes *layoutAttributes = nil;
@@ -261,6 +273,10 @@ static char kPSTCachedItemRectsKey;
 }
 
 - (CGSize)collectionViewContentSize {
+    if (!_data) {
+        [self prepareLayout];
+    }
+    
     //    return _currentLayoutSize;
     return _data.contentSize;
 }
@@ -278,6 +294,7 @@ static char kPSTCachedItemRectsKey;
 - (void)invalidateLayout {
     [super invalidateLayout];
     objc_setAssociatedObject(self, &kPSTCachedItemRectsKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    _data = nil;
 }
 
 - (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds {


### PR DESCRIPTION
In UICollectionView, you can ask for the layout size, etc, when the layout isn't fully loaded yet. This fixes that by always loading in the various methods if _data isn't set yet (i.e. the layout isn't prepared yet). Also need to clear _data in invalidateLayout to make this work, but also, that should be done anyway.
