### PR TITLE
Fix associated object disappearing

### DIFF
--- a/PSTCollectionView/PSTCollectionViewFlowLayout.m
+++ b/PSTCollectionView/PSTCollectionViewFlowLayout.m
@@ -83,9 +83,6 @@ NSString *const PSTFlowLayoutRowVerticalAlignmentKey = @"UIFlowLayoutRowVertical
                 // TODO: those values are some enum. find out what that is.
                 PSTFlowLayoutRowVerticalAlignmentKey : @(1),
         };
-
-        // custom ivars
-        objc_setAssociatedObject(self, &kPSTCachedItemRectsKey, [NSMutableDictionary dictionary], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
     return self;
 }
@@ -294,6 +291,9 @@ static char kPSTCachedItemRectsKey;
 }
 
 - (void)prepareLayout {
+    // custom ivars
+    objc_setAssociatedObject(self, &kPSTCachedItemRectsKey, [NSMutableDictionary dictionary], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    
     _data = [PSTGridLayoutInfo new]; // clear old layout data
     _data.horizontal = self.scrollDirection == PSTCollectionViewScrollDirectionHorizontal;
     CGSize collectionViewSize = self.collectionView.bounds.size;


### PR DESCRIPTION
The associated object gets cleared out in invalidate layout, so it
makes sense to add it in prepare layout. Otherwise, once the layout has
been invalidated once, the associated object is gone forever and won't
ever be created again.
