### PR TITLE
fix dynamic class creation on iOS 5

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -2253,7 +2253,7 @@ static BOOL PSTRegisterClass(NSString *UIClassName, Class PSTClass) {
 
     }else {
         // We're most likely on iOS5, the requested UIKit class doesn't exist, so we create it dynamically.
-        if ((UIClass = objc_allocateClassPair(PSTCollectionView.class, UIClassName.UTF8String, 0))) {  objc_registerClassPair(UIClass);
+        if ((UIClass = objc_allocateClassPair(PSTClass, UIClassName.UTF8String, 0))) {  objc_registerClassPair(UIClass);
         }
     }
     return YES;


### PR DESCRIPTION
Fix an issue that when using a collection view in a nib file on iOS <= 5, all the classes that are dynamically created from the nib file will be subclasses of PSTCollectionView.
