### PR TITLE
Crash while moving Cells - Tested on iOS 5.1

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -2092,11 +2092,10 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
                     [newModel insertObject:section atIndex:updateItem.indexPathAfterUpdate.section];
                 }
                 else {
-                    NSUInteger originalIndex = [newModel[updateItem.indexPathBeforeUpdate.section] indexOfObject:@(updateItem.indexPathBeforeUpdate.item)];
-                    id object = newModel[updateItem.indexPathBeforeUpdate.section][originalIndex];
-                    [newModel[updateItem.indexPathBeforeUpdate.section] removeObjectAtIndex:originalIndex];
+                    id object = @([oldCollectionViewData globalIndexForItemAtIndexPath:updateItem.indexPathBeforeUpdate]);
+                    [newModel[updateItem.indexPathBeforeUpdate.section] removeObject:object];
                     [newModel[updateItem.indexPathAfterUpdate.section] insertObject:object
-                            atIndex:updateItem.indexPathAfterUpdate.item];
+                                                                            atIndex:updateItem.indexPathAfterUpdate.item];
                 }
             }
                 break;


### PR DESCRIPTION
I was trying to create a Drag & Drop CollectionView and it was working fine in iOS 6.
But using PSTCollectionView only works moving cells from the first section.

``` objectivec
NSUInteger originalIndex = [newModel[updateItem.indexPathBeforeUpdate.section] indexOfObject:@(updateItem.indexPathBeforeUpdate.item)];
id object = newModel[updateItem.indexPathBeforeUpdate.section][originalIndex];
```

`originalIndex` was `NSNotFound` so it crash.

because it was only looking for objects only in the first section, so by doing this:

``` objectivec
id object = @([oldCollectionViewData globalIndexForItemAtIndexPath:updateItem.indexPathBeforeUpdate]);
```

is using the global index who was stored in the `newModel` array

Let me know if I'm wrong.

Thanks Guys! PSTCollectionView it's helping me a lot.
