### PR TITLE
viewDidLoad Fix

### DIFF
--- a/PSTCollectionView/PSTCollectionViewController.m
+++ b/PSTCollectionView/PSTCollectionViewController.m
@@ -110,7 +110,11 @@
 			_collectionView.delegate = self;
 			_collectionView.dataSource = self;
 			
-			[self viewDidLoad];
+			if (self.view != self.collectionView) {
+				[self.view addSubview:self.collectionView];
+				self.collectionView.frame = self.view.bounds;
+				self.collectionView.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
+			}
 		}
     }
     return _collectionView;


### PR DESCRIPTION
Calls `viewDidLoad` after lazy loading the collectionView.

Wraps lazy loading in an auto release pool in case lazy loading occurs while the collection view controller is being deallocated.

[Fixes #339]
