### PR TITLE
Dequeue CollectionCell - apply the attribute (bounds) only once.

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -450,11 +450,6 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
                 cell = [cellClass new];
             }
         }
-        PSTCollectionViewLayout *layout = [self collectionViewLayout];
-        if ([layout isKindOfClass:PSTCollectionViewFlowLayout.class]) {
-            CGSize itemSize = ((PSTCollectionViewFlowLayout *)layout).itemSize;
-            cell.bounds = CGRectMake(0, 0, itemSize.width, itemSize.height);
-        }
         cell.collectionView = self;
         cell.reuseIdentifier = identifier;
     }


### PR DESCRIPTION
The cell bounds will be set by the last method call ([cell applyLayoutAttributes:attributes]).

I have a collection view with different cell sizes and I did't bother updating layout.itemSize (50x50). 

The problem appeared when I dequeue a new cell with size 1024x400. Then the cell is scaled down to 50x50 and all it's subviews that did have a height greater than 50 will be set to 0 (because of autoresizing mask). After applying the actual cell size, this view will have their height calculated incorrectly.

By removing that section of code, I don't see any side effects.

Thanks,
Alex
