### PR TITLE
Invalidate Layout on Bounds Change

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -277,6 +277,16 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
     }
 }
 
+- (void)setBounds:(CGRect)bounds {
+    if (!CGRectEqualToRect(bounds, self.bounds)) {
+        [super setBounds:bounds];
+        if ([self.collectionViewLayout shouldInvalidateLayoutForBoundsChange:bounds]) {
+            [self invalidateLayout];
+            _collectionViewFlags.fadeCellsForBoundsChange = YES;
+        }
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - UIScrollViewDelegate
 


### PR DESCRIPTION
Until now, the collection view has only invalidated the layout if the frame did change. To implement something like floating section headers, the layout must also be invalidated on each change of the bounds.

Also the frame of the collection view has been passed to the layout while asking for invalidation. This should be the bounds of the view. For this I changed the order in the method 'setFrame' and used the bounds.
