### PR TITLE
Bug fix in  -[PSTCollectionViewData updateItemCounts]

### DIFF
--- a/PSTCollectionView/PSTCollectionViewData.m
+++ b/PSTCollectionView/PSTCollectionViewData.m
@@ -203,6 +203,7 @@
         _numItems = 0;
         free(_sectionItemCounts);
         _sectionItemCounts = 0;
+        _collectionViewDataFlags.itemCountsAreValid = YES;
         return;
     }
     // allocate space


### PR DESCRIPTION
Mark the collection view data as valid, also in case of the early bail-out. This bug occurs, if collection initially shows now items and is updated via a batch update.
