### PR TITLE
Updated .podspec for 1.1.0 release

### DIFF
--- a/PSTCollectionView.podspec
+++ b/PSTCollectionView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'PSTCollectionView'
-  s.version = '1.0.0'
+  s.version = '1.1.0'
   s.summary = 'Open Source, 100% API compatible replacement of UICollectionView for iOS4+.'
   s.homepage = 'https://github.com/steipete/PSTCollectionView'
   s.license = {


### PR DESCRIPTION
As discussed on twitter, updated podspec for a 1.1.0 release. I guess a tag isn't included in a pull request so you would have to tag this commit with 1.1.0 after merging. 

If you done, I'll make sure the cocoapods repo gets updated too.
