### PR TITLE
Correctly decoding reuseIdentifier when loading from Nib

### DIFF
--- a/PSTCollectionView/PSTCollectionViewCell.m
+++ b/PSTCollectionView/PSTCollectionViewCell.m
@@ -34,6 +34,7 @@
 
 - (id)initWithCoder:(NSCoder *)aDecoder {
     if ((self = [super initWithCoder:aDecoder])) {
+        self.reuseIdentifier = [aDecoder decodeObjectForKey:@"UIReuseIdentifier"];
     }
     return self;
 }


### PR DESCRIPTION
This issue was mentioned in #309 but never got fixed.

Here's the missing pull request. Close this and #309 after merging.

Thanks
