### PR TITLE
Avoid re-loading UIKit for simulator drag.

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -2298,8 +2298,7 @@ CGFloat PSTSimulatorAnimationDragCoefficient(void) {
 #import <dlfcn.h>
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        void *UIKit = dlopen([[[NSBundle bundleForClass:UIApplication.class] executablePath] fileSystemRepresentation], RTLD_LAZY);
-        UIAnimationDragCoefficient = (CGFloat (*)(void))dlsym(UIKit, "UIAnimationDragCoefficient");
+        UIAnimationDragCoefficient = (CGFloat (*)(void))dlsym(RTLD_DEFAULT, "UIAnimationDragCoefficient");
     });
 #endif
     return UIAnimationDragCoefficient ? UIAnimationDragCoefficient() : 1.f;


### PR DESCRIPTION
PSTCollectionView depends on UIKit, so UIKit must be loaded into memory. Rather than finding the path and calling dlopen(), just search the existing symbols.
