### PR TITLE
Fixed issue on -shouldInvalidateLayoutForBoundsChange:

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -271,8 +271,10 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
 
 - (void)setFrame:(CGRect)frame {
     if (!CGRectEqualToRect(frame, self.frame)) {
+        CGRect bounds = (CGRect){.origin=self.contentOffset, .size=frame.size};
+        BOOL shouldInvalidate = [self.collectionViewLayout shouldInvalidateLayoutForBoundsChange:bounds];
         [super setFrame:frame];
-        if ([self.collectionViewLayout shouldInvalidateLayoutForBoundsChange:self.bounds]) {
+        if (shouldInvalidate) {
             [self invalidateLayout];
             _collectionViewFlags.fadeCellsForBoundsChange = YES;
         }
@@ -281,8 +283,9 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
 
 - (void)setBounds:(CGRect)bounds {
     if (!CGRectEqualToRect(bounds, self.bounds)) {
+        BOOL shouldInvalidate = [self.collectionViewLayout shouldInvalidateLayoutForBoundsChange:bounds];
         [super setBounds:bounds];
-        if ([self.collectionViewLayout shouldInvalidateLayoutForBoundsChange:bounds]) {
+        if (shouldInvalidate) {
             [self invalidateLayout];
             _collectionViewFlags.fadeCellsForBoundsChange = YES;
         }


### PR DESCRIPTION
Now the collection view asks the layout wether it should invalidate, before actually changing the frame or bounds of the collection view.

I noticed that when using a UICollectionView, and rotating the device, the method got called before the rotation occurred, handing the new frame on the argument. Thus I made a simple comparison, if the widths changed, then return YES.

When testing the same code in the PSTCollectionView, I noticed the layout didn't invalidate, and after debugging, I realized that the method was being called with the new self.bounds, checking the source code, I noticed the issue, and corrected it.
