### PR TITLE
indexPathForItemAtPoint: does not return an indexPath when the cell isn't visible

### DIFF
--- a/PSTCollectionView/PSTCollectionView.m
+++ b/PSTCollectionView/PSTCollectionView.m
@@ -613,18 +613,8 @@ static void PSTCollectionViewCommonSetup(PSTCollectionView *_self) {
 }
 
 - (NSIndexPath *)indexPathForItemAtPoint:(CGPoint)point {
-    __block NSIndexPath *indexPath = nil;
-    [_allVisibleViewsDict enumerateKeysAndObjectsWithOptions:kNilOptions usingBlock:^(id key, id obj, BOOL *stop) {
-        PSTCollectionViewItemKey *itemKey = (PSTCollectionViewItemKey *)key;
-        if (itemKey.type == PSTCollectionViewItemTypeCell) {
-            PSTCollectionViewCell *cell = (PSTCollectionViewCell *)obj;
-            if (CGRectContainsPoint(cell.frame, point) && cell.userInteractionEnabled) {
-                indexPath = itemKey.indexPath;
-                *stop = YES;
-            }
-        }
-    }];
-    return indexPath;
+    PSTCollectionViewLayoutAttributes *attributes = [[self.collectionViewLayout layoutAttributesForElementsInRect:CGRectMake(point.x, point.y, 1, 1)] lastObject];
+    return attributes.indexPath;
 }
 
 - (NSIndexPath *)indexPathForCell:(PSTCollectionViewCell *)cell {


### PR DESCRIPTION
I noticed an issue with `-[PSTCollectionView indexPathForItemAtPoint:]` where it just returns `nil` if the point represents a cell that is not visible yet. For example, when using this delegate method:

``` objective-c
- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset
{
    CGPoint point = CGPointMake(targetContentOffset->x, targetContentOffset->y);
    NSIndexPath *indexPath = [self.collectionView indexPathForItemAtPoint:point];
}
```

`indexPath` will be nil if the `targetContentOffset` is not yet visible. This occurs when swiping very fast, or flicking the scroll view fast enough to give it a lot of velocity.

These changes appear to fix the issue, considering all items in the collection view. I don't know if this is the most efficient way to fix the issue, but it does resolve it and UICollectionView does behave this way anyway.

Let me know if you need anything.
