### PR TITLE
Updated podspec version to 1.2.1

### DIFF
--- a/PSTCollectionView.podspec
+++ b/PSTCollectionView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'PSTCollectionView'
-  s.version = '1.2.0'
+  s.version = '1.2.1'
   s.summary = 'Open Source, 100% API compatible replacement of UICollectionView for iOS4+.'
   s.homepage = 'https://github.com/steipete/PSTCollectionView'
   s.license = {


### PR DESCRIPTION
Bumped version number to reflect iOS 8 fixes.
In order for this change to be in effect, @steipete will need to Tag the merged request as '1.2.1'
