### PR TITLE
Added cell preload options

### DIFF
--- a/PSTCollectionView/PSTCollectionView.h
+++ b/PSTCollectionView/PSTCollectionView.h
@@ -48,6 +48,7 @@ typedef NS_ENUM(NSUInteger, PSTCollectionElementCategory) {
 @property (nonatomic, assign) IBOutlet id<PSTCollectionViewDataSource> dataSource;
 @property (nonatomic, strong) UIView *backgroundView; // will be automatically resized to track the size of the collection view and placed behind all cells and supplementary views.
 
+
 // For each reuse identifier that the collection view will use, register either a class or a nib from which to instantiate a cell.
 // If a nib is registered, it must contain exactly 1 top level object which is a PSTCollectionViewCell.
 // If a class is registered, it will be instantiated via alloc/initWithFrame:

--- a/PSTCollectionView/PSTCollectionViewFlowLayout.h
+++ b/PSTCollectionView/PSTCollectionViewFlowLayout.h
@@ -52,6 +52,25 @@ typedef NS_ENUM(NSInteger, PSTCollectionViewScrollDirection) {
  */
 @property (nonatomic, strong) NSDictionary *rowAlignmentOptions;
 
+typedef NS_OPTIONS(NSUInteger, PSTCollectionViewLayoutPreload) {
+    PSTCollectionViewLayoutPreloadNone,
+    PSTCollectionViewLayoutPreloadBelow = 1,
+    PSTCollectionViewLayoutPreloadRight = 2,
+    PSTCollectionViewLayoutPreloadLeft = 4,
+    PSTCollectionViewLayoutPreloadAbove = 8,
+} ;
+
+/// The bit mask determining on which directions we will be preloading one cell
+@property (nonatomic, assign) PSTCollectionViewLayoutPreload preloadMask;
+
+typedef NS_OPTIONS(NSUInteger, PSTCollectionViewLayoutPreloadAmount) {
+    PSTCollectionViewLayoutPreloadAmountOneCell,
+    PSTCollectionViewLayoutPreloadAmountOneScreen,
+} ;
+
+/// This determines whether to preload just one cell or one screen, if preloadMask is enabled
+@property (nonatomic, assign) PSTCollectionViewLayoutPreloadAmount preloadAmount;
+
 @end
 
 // @steipete addition, private API in UICollectionViewFlowLayout


### PR DESCRIPTION
Hello,
I'd really appreciate if you are willing to take this pull request although this isn't a feature of UICollectionView.

The main reason I use PSTCollectionView is that it's really hard to find a clean solution for preloading an extra row with either UITableView or UICollectionView. One way is to make the collection view size larger than the screen, it breaks pagination and makes the scrolling perf bad. If I try to manually maintain a dictionary of preloaded cells in scrollViewDidEndDecelerating, it would be buggy if I try to create preloaded cells with dequeueReusableCellWithReuseIdentifier (cells loaded on screen can sometimes/unpredictably be removed because of the dequeue.. call for the preloading), and really hard if I try to preload cells without dequeueReusableCellWithReuseIdentifier when there are multiple cell classes (and bad for perf too). Another solution is to just preload the images, but it's also challenging when there are different cell classes with different layouts that can lead to different image sizes.

So an open-source collection view is the probably best solution i can find right now. I'm guessing that this could be helpful for some other people too. This should introduce any difference if the user doesn't set the preloadMask property.

Thank you so much for creating such an awesome library!
